### PR TITLE
fix(client): Make betting UI state-driven and robust

### DIFF
--- a/client/src/pages/GameRoom.jsx
+++ b/client/src/pages/GameRoom.jsx
@@ -1086,29 +1086,39 @@ const GameRoom = () => {
     );
   };
   
+  // Efeito para gerenciar a visibilidade dos diálogos de resposta com base no gameState
+  useEffect(() => {
+    if (!gameState || !socket) return;
+
+    const currentPlayer = gameState.players.find(p => p.id === socket.id);
+    if (!currentPlayer) return;
+
+    const { trucoState, retrucoState, vale4State } = gameState;
+
+    // Lógica para mostrar o diálogo de resposta ao Truco
+    if (trucoState && !trucoState.accepted && trucoState.respondingTeam === currentPlayer.team) {
+      setShowTrucoResponseDialog(true);
+    } else {
+      setShowTrucoResponseDialog(false);
+    }
+
+    // Lógica para mostrar o diálogo de resposta ao Retruco
+    if (retrucoState && !retrucoState.accepted && retrucoState.respondingTeam === currentPlayer.team) {
+      setShowRetrucoResponseDialog(true);
+    } else {
+      setShowRetrucoResponseDialog(false);
+    }
+
+    // Lógica para mostrar o diálogo de resposta ao Vale 4
+    if (vale4State && !vale4State.accepted && vale4State.respondingTeam === currentPlayer.team) {
+      setShowVale4ResponseDialog(true);
+    } else {
+      setShowVale4ResponseDialog(false);
+    }
+  }, [gameState, socket]);
+
   useEffect(() => {
     if (socket) {
-      socket.on('truco_requested', (data) => {
-        const currentPlayer = gameState?.players.find(p => p.id === socket.id);
-        if (currentPlayer && currentPlayer.team === data.trucoState.respondingTeam) {
-          setShowTrucoResponseDialog(true);
-        }
-      });
-
-      socket.on('retruco_requested', (data) => {
-        const currentPlayer = gameState?.players.find(p => p.id === socket.id);
-        if (currentPlayer && currentPlayer.team === data.retrucoState.respondingTeam) {
-          setShowRetrucoResponseDialog(true);
-        }
-      });
-
-      socket.on('vale4_requested', (data) => {
-        const currentPlayer = gameState?.players.find(p => p.id === socket.id);
-        if (currentPlayer && currentPlayer.team === data.vale4State.respondingTeam) {
-          setShowVale4ResponseDialog(true);
-        }
-      });
-
       let isHandlingTrucoResponse = false;
       let isHandlingRetrucoResponse = false;
       let isHandlingVale4Response = false;
@@ -1415,9 +1425,6 @@ const GameRoom = () => {
       });
 
       return () => {
-        socket.off('truco_requested');
-        socket.off('retruco_requested');
-        socket.off('vale4_requested');
         socket.off('truco_response_received');
         socket.off('retruco_response_received');
         socket.off('vale4_response_received');


### PR DESCRIPTION
This commit fixes a critical bug where the game would get stuck waiting for a response to a bet ('truco', 'retruco', 'vale 4'). The previous fix was incomplete because it relied on socket events that could be missed if a user disconnected.

This new implementation makes the client-side UI for betting dialogs purely state-driven, using the `gameState` object as the single source of truth. This ensures that the UI is always in sync with the game's state and prevents the game from freezing.

Key changes:
- Added a `useEffect` hook in `GameRoom.jsx` that listens for changes to `gameState`.
- The hook checks `trucoState`, `retrucoState`, and `vale4State` to determine if the current player's team is the responding team and shows the appropriate dialog.
- Removed the flawed `useEffect` hooks that listened for the `truco_requested`, `retruco_requested`, and `vale4_requested` socket events.
- Removed the corresponding `socket.off` calls for the removed event listeners.