### PR TITLE
Ensure player teams are included in game state responses

### DIFF
--- a/server/models/TrucoGame.js
+++ b/server/models/TrucoGame.js
@@ -952,6 +952,7 @@ class TrucoGame {
           isReady: player.isReady,
           connected: true,
           socketId: player.id,
+          team: player.team,
           isCurrentPlayer: player.isCurrentPlayer,
           hand: player.hand ? player.hand.map(card => ({
             value: card.value,
@@ -964,6 +965,7 @@ class TrucoGame {
         console.log('Estado transformado:', {
           id: playerState.id,
           name: playerState.name,
+          team: playerState.team,
           isReady: playerState.isReady,
           cards: playerState.hand.length
         });

--- a/server/test/TrucoGame.test.js
+++ b/server/test/TrucoGame.test.js
@@ -426,6 +426,27 @@ describe('TrucoGame', () => {
   });
 
   describe('Betting Flow', () => {
+    it('deve incluir as informações de time no estado do jogo', () => {
+      const newGame = new TrucoGame('room1', 4);
+      newGame.addPlayer('player1', 'Jogador 1');
+      newGame.addPlayer('player2', 'Jogador 2');
+      newGame.addPlayer('player3', 'Jogador 3');
+      newGame.addPlayer('player4', 'Jogador 4');
+
+      // Marcar todos como prontos para garantir que o estado do jogo esteja atualizado
+      newGame.setPlayerReady('player1');
+      newGame.setPlayerReady('player2');
+      newGame.setPlayerReady('player3');
+      newGame.setPlayerReady('player4');
+
+      const gameState = newGame.getGameState();
+
+      gameState.players.forEach((player, index) => {
+        const expectedTeam = (index % 2) + 1;
+        assert.strictEqual(player.team, expectedTeam, `Jogador ${player.id} deveria estar no time ${expectedTeam}`);
+      });
+    });
+
     it('deve lidar corretamente com a sequência de truco -> retruco -> vale 4', () => {
       const newGame = new TrucoGame('room1', 2);
       newGame.addPlayer('player1', 'Jogador 1');


### PR DESCRIPTION
## Summary
- include the player team value when building the game state sent to clients so vale 4 prompts can resolve
- add a regression test to confirm each player in the game state exposes its team assignment

## Testing
- npm test (server)


------
https://chatgpt.com/codex/tasks/task_e_68e6c91031d88320807cf52e2bd6543a